### PR TITLE
Making remotely-executed bash cmd literal a raw string

### DIFF
--- a/remtool.py
+++ b/remtool.py
@@ -238,7 +238,7 @@ class reMarkable:
         return True
 
     def _get_metadata(self):
-        cmd = '''
+        cmd = r'''
 shopt -s nullglob
 metafiles=(.local/share/remarkable/xochitl/*.metadata)
 numfiles=${#metafiles[@]}


### PR DESCRIPTION
There is a bash cmd string literal defined and used in _get_metadata(). On python 3.12 I get a SyntaxWarning about an "invalid escape sequence '\' ", since python is parsing the escape sequences in the bash command string literal. Those sequences are meant for bash, so making the string raw keeps python from interpreting them.