### PR TITLE
Fix broken file overwrites and handle cases where target folder is unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple CLI tool for transferring files to a reMarkable 2 or reMarkable Paper P
 - python 3.8+
 - reMarkable 2 or reMarkable Paper Pro
 
-**NOTE:** As of May 2025, this tool has been tested with python 3.11 and reMarkable 3.11.* through 3.19.*
+**NOTE:** As of July 2026, this tool has been tested with python 3.11+ and supports reMarkable 3.27. Older versions of the reMarkable software are no longer supported in remtool version 0.4.
 
 **Developer Mode** and SSH must be enabled on the target device for this tool to work.
 

--- a/remtool.py
+++ b/remtool.py
@@ -511,7 +511,7 @@ class ContentTree:
 
 
 if __name__ == "__main__":
-    args = docopt(__doc__, default_help=True, version='remtool 0.3')
+    args = docopt(__doc__, default_help=True, version='remtool 0.4')
 
     reM = reMarkable(CONFIG['SSH_HOSTNAME'])
 
@@ -522,6 +522,11 @@ if __name__ == "__main__":
             if (args['FILE'][-1] == '.'
                     or reM.ct.get_node_by_path(args['FILE'][-1])):
                 args['FOLDER'] = args['FILE'].pop()
+        elif args['FOLDER'] is None and len(args['FILE']) == 1:
+            print(colored('BOLDYELLOW',
+                          'Warning, no folder specified, '
+                          'copying to root folder...'))
+            args['FOLDER'] = '.'
 
         for file in args['FILE']:
             reM.put(file, args['FOLDER'], args['-f'], args['--clear'], True)

--- a/remtool.py
+++ b/remtool.py
@@ -249,7 +249,7 @@ for file in ${metafiles[@]}
 do
     uuid="${file%.*}"
     tmp=`grep fileType $uuid.content`
-    if [[ $tmp =~ :\ \\"(.+)\\", ]]; then
+    if [[ $tmp =~ :\ \"(.+)\", ]]; then
         filetype=${BASH_REMATCH[1]}
     else
         filetype=""


### PR DESCRIPTION
This change resolves two issues:
1. Recent changes to the reMarkable software on-device broke overwriting files via the `put` command. Not sure exactly which update broke things, but it likely happened with 3.27 or the update before.
2. The `put` command was not gracefully handling the case where a target folder is unspecified. (See issue #8)

Regarding the second issue, I've chosen to display a warning message and default to the root device folder if a target folder isn't specified. This is how _I_ would like it to work, but I'm open to hearing opinions if you're feeling strongly enough to tell me about them.

Special thanks to @sprkie for letting me know about this issue.